### PR TITLE
Migrate to shared steps-check workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,10 +1,13 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
+include:
+- repository: steps-check
+  branch: master
+  path: steps.bitrise.yml
+
 workflows:
-  check:
-    steps:
-    - git::https://github.com/bitrise-steplib/steps-check.git: { }
+  # check: included from steps-check/steps.bitrise.yml
 
   e2e:
     steps:
@@ -32,4 +35,4 @@ workflows:
 
   generate_readme:
     steps:
-    - git::https://github.com/bitrise-steplib/steps-readme-generator.git@main: { }
+    - git::https://github.com/bitrise-steplib/steps-readme-generator.git@main: {}

--- a/gitclone/bitriseapi/pr_merge_ref.go
+++ b/gitclone/bitriseapi/pr_merge_ref.go
@@ -48,10 +48,10 @@ type mergeRefFetcher func(attempt uint) (mergeRefResponse, error)
 
 func (c apiMergeRefChecker) IsMergeRefUpToDate(ref string) (bool, error) {
 	if c.buildURL == "" {
-		return false, fmt.Errorf("Bitrise build URL is not defined")
+		return false, fmt.Errorf("Bitrise build URL is not defined") //nolint:staticcheck
 	}
 	if c.apiToken == "" {
-		return false, fmt.Errorf("Bitrise API token is not defined")
+		return false, fmt.Errorf("Bitrise API token is not defined") //nolint:staticcheck
 	}
 
 	startTime := time.Now()

--- a/gitclone/bitriseapi/pr_patch.go
+++ b/gitclone/bitriseapi/pr_patch.go
@@ -32,10 +32,10 @@ type apiPatchSource struct {
 
 func (s apiPatchSource) GetPRPatch() (string, error) {
 	if s.buildURL == "" {
-		return "", fmt.Errorf("Bitrise build URL is not defined")
+		return "", fmt.Errorf("Bitrise build URL is not defined") //nolint:staticcheck
 	}
 	if s.apiToken == "" {
-		return "", fmt.Errorf("Bitrise API token is not defined")
+		return "", fmt.Errorf("Bitrise API token is not defined") //nolint:staticcheck
 	}
 
 	u, err := url.Parse(s.buildURL)

--- a/gitclone/checkout_method_pr_auto_merge_branch.go
+++ b/gitclone/checkout_method_pr_auto_merge_branch.go
@@ -51,7 +51,7 @@ func (c checkoutPRMergeRef) do(gitCmd git.Git, fetchOpts fetchOptions, fallback 
 	return nil
 }
 
-func (c checkoutPRMergeRef) performCheckout(gitCmd git.Git, fetchOpts fetchOptions, fallback fallbackRetry) error {
+func (c checkoutPRMergeRef) performCheckout(gitCmd git.Git, fetchOpts fetchOptions, _ fallbackRetry) error {
 	// https://git-scm.com/book/en/v2/Git-Internals-The-Refspec
 	refSpec := fmt.Sprintf("%s:%s", c.remoteMergeRef(), c.localMergeRef())
 

--- a/gitclone/git.go
+++ b/gitclone/git.go
@@ -198,7 +198,6 @@ func handleCheckoutError(callback getAvailableBranches, tag string, err error, s
 				tag,
 				err,
 				shortMsg,
-				branch,
 				branches,
 			)
 		}

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -387,7 +387,6 @@ func Test_checkoutState(t *testing.T) {
 				fetchFailedTag,
 				fmt.Errorf("fetch branch refs/heads/fake: %w: please make sure the branch still exists", errors.New(rawCmdError)),
 				"Fetching repository has failed",
-				"fake",
 				[]string{"master"},
 			),
 		},

--- a/gitclone/steperror.go
+++ b/gitclone/steperror.go
@@ -36,7 +36,7 @@ func newStepError(tag string, err error, shortMsg string) error {
 	return step.NewError("git-clone", tag, err, shortMsg)
 }
 
-func newStepErrorWithBranchRecommendations(tag string, err error, shortMsg, _ string, availableBranches []string) error {
+func newStepErrorWithBranchRecommendations(tag string, err error, shortMsg string, availableBranches []string) error {
 	// First: Map the error messages
 	newErr := newStepError(tag, err, shortMsg)
 

--- a/gitclone/steperror.go
+++ b/gitclone/steperror.go
@@ -36,7 +36,7 @@ func newStepError(tag string, err error, shortMsg string) error {
 	return step.NewError("git-clone", tag, err, shortMsg)
 }
 
-func newStepErrorWithBranchRecommendations(tag string, err error, shortMsg, currentBranch string, availableBranches []string) error {
+func newStepErrorWithBranchRecommendations(tag string, err error, shortMsg, _ string, availableBranches []string) error {
 	// First: Map the error messages
 	newErr := newStepError(tag, err, shortMsg)
 
@@ -78,7 +78,7 @@ Our auto-configurator returned the following error:
 	}
 }
 
-func newUpdateSubmoduleFailedAuthenticationDetailedError(errorMsg string, params ...string) errormapper.DetailedError {
+func newUpdateSubmoduleFailedAuthenticationDetailedError(errorMsg string, _ ...string) errormapper.DetailedError {
 	return errormapper.DetailedError{
 		Title: "We couldn’t access one or more of your Git submodules.",
 		Description: fmt.Sprintf(`You can try accessing your submodules <a target="_blank" href="https://devcenter.bitrise.io/faq/adding-projects-with-submodules/">using an SSH key</a>. You can continue adding your app, but your builds will fail unless you fix this issue later.
@@ -138,14 +138,14 @@ func newFetchFailedGenericDetailedError(errorMsg string) errormapper.DetailedErr
 	}
 }
 
-func newFetchFailedSSHAccessErrorDetailedError(errorMsg string, params ...string) errormapper.DetailedError {
+func newFetchFailedSSHAccessErrorDetailedError(_ string, _ ...string) errormapper.DetailedError {
 	return errormapper.DetailedError{
 		Title:       "We couldn’t access your repository.",
 		Description: "Please abort the process, double-check your SSH key and try again.",
 	}
 }
 
-func newFetchFailedCouldNotFindGitRepoDetailedError(errorMsg string, params ...string) errormapper.DetailedError {
+func newFetchFailedCouldNotFindGitRepoDetailedError(_ string, params ...string) errormapper.DetailedError {
 	repoURL := errormapper.GetParamAt(0, params)
 	return errormapper.DetailedError{
 		Title:       fmt.Sprintf("We couldn’t find a git repository at '%s'.", repoURL),
@@ -153,14 +153,14 @@ func newFetchFailedCouldNotFindGitRepoDetailedError(errorMsg string, params ...s
 	}
 }
 
-func newFetchFailedHTTPAccessErrorDetailedError(errorMsg string, params ...string) errormapper.DetailedError {
+func newFetchFailedHTTPAccessErrorDetailedError(_ string, _ ...string) errormapper.DetailedError {
 	return errormapper.DetailedError{
 		Title:       "We couldn’t access your repository.",
 		Description: "Please abort the process and try again, by providing the repository with SSH URL.",
 	}
 }
 
-func newFetchFailedCouldConnectErrorDetailedError(errorMsg string, params ...string) errormapper.DetailedError {
+func newFetchFailedCouldConnectErrorDetailedError(_ string, params ...string) errormapper.DetailedError {
 	host := errormapper.GetParamAt(0, params)
 	return errormapper.DetailedError{
 		Title:       fmt.Sprintf("We couldn’t connect to '%s'.", host),
@@ -168,14 +168,14 @@ func newFetchFailedCouldConnectErrorDetailedError(errorMsg string, params ...str
 	}
 }
 
-func newFetchFailedSamlSSOEnforcedDetailedError(errorMsg string, params ...string) errormapper.DetailedError {
+func newFetchFailedSamlSSOEnforcedDetailedError(_ string, _ ...string) errormapper.DetailedError {
 	return errormapper.DetailedError{
 		Title:       "To access this repository, you need to use SAML SSO.",
 		Description: `Please abort the process, update your SSH settings and try again. You can find out more about <a target="_blank" href="https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/authorizing-an-ssh-key-for-use-with-saml-single-sign-on">using SAML SSO in the Github docs</a>.`,
 	}
 }
 
-func newInvalidBranchDetailedError(errorMsg string, params ...string) errormapper.DetailedError {
+func newInvalidBranchDetailedError(_ string, params ...string) errormapper.DetailedError {
 	branch := errormapper.GetParamAt(0, params)
 	return errormapper.DetailedError{
 		Title:       fmt.Sprintf("We couldn't find the branch '%s'.", branch),

--- a/gitclone/steperror_test.go
+++ b/gitclone/steperror_test.go
@@ -385,7 +385,6 @@ func Test_newStepErrorWithBranchRecommendations(t *testing.T) {
 		tag               string
 		err               error
 		shortMsg          string
-		currentBranch     string
 		availableBranches []string
 	}
 	tests := []struct {
@@ -399,7 +398,6 @@ func Test_newStepErrorWithBranchRecommendations(t *testing.T) {
 				tag:               "checkout_failed",
 				err:               errors.New("Generic error"),
 				shortMsg:          "Checkout has failed",
-				currentBranch:     "feature1",
 				availableBranches: nil,
 			},
 			want: &step.Error{
@@ -421,7 +419,6 @@ func Test_newStepErrorWithBranchRecommendations(t *testing.T) {
 				tag:               "checkout_failed",
 				err:               errors.New("pathspec 'feature1' did not match any file(s) known to git"),
 				shortMsg:          "Checkout has failed",
-				currentBranch:     "feature1",
 				availableBranches: []string{"master", "develop", "hotfix"},
 			},
 			want: &step.Error{
@@ -441,7 +438,7 @@ func Test_newStepErrorWithBranchRecommendations(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := newStepErrorWithBranchRecommendations(tt.args.tag, tt.args.err, tt.args.shortMsg, tt.args.currentBranch, tt.args.availableBranches); !reflect.DeepEqual(got, tt.want) {
+			if got := newStepErrorWithBranchRecommendations(tt.args.tag, tt.args.err, tt.args.shortMsg, tt.args.availableBranches); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("newStepErrorWithBranchRecommendations() = %v,want %v", got, tt.want)
 			}
 		})

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/errorutil"
-	. "github.com/bitrise-io/go-utils/v2/exitcode"
+	"github.com/bitrise-io/go-utils/v2/exitcode"
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/bitrise-steplib/steps-git-clone/gitclone/tracker"
@@ -20,33 +20,33 @@ func main() {
 	os.Exit(int(exitCode))
 }
 
-func run() ExitCode {
+func run() exitcode.ExitCode {
 	logger := log.NewLogger()
 	gitCloneStep := createStep(logger)
 
 	cfg, err := gitCloneStep.ProcessConfig()
 	if err != nil {
 		logger.Println()
-		logger.Errorf("%s", errorutil.FormattedError(fmt.Errorf("Failed to process Step inputs: %w", err)))
-		return Failure
+		logger.Errorf("%s", errorutil.FormattedError(fmt.Errorf("failed to process Step inputs: %w", err)))
+		return exitcode.Failure
 	}
 
 	result, err := gitCloneStep.Run(cfg)
 	if err != nil {
 		logger.Println()
-		logger.Errorf("%s", errorutil.FormattedError(fmt.Errorf("Failed to execute Step: %w", err)))
-		return Failure
+		logger.Errorf("%s", errorutil.FormattedError(fmt.Errorf("failed to execute Step: %w", err)))
+		return exitcode.Failure
 	}
 
 	err = gitCloneStep.ExportOutputs(result)
 	if err != nil {
 		logger.Println()
-		logger.Errorf("%s", errorutil.FormattedError(fmt.Errorf("Failed to export Step outputs: %w", err)))
+		logger.Errorf("%s", errorutil.FormattedError(fmt.Errorf("failed to export Step outputs: %w", err)))
 	}
 
 	fmt.Println()
 	logger.Donef("Success")
-	return Success
+	return exitcode.Success
 }
 
 func createStep(logger log.Logger) step.GitCloneStep {

--- a/main.go
+++ b/main.go
@@ -27,21 +27,21 @@ func run() exitcode.ExitCode {
 	cfg, err := gitCloneStep.ProcessConfig()
 	if err != nil {
 		logger.Println()
-		logger.Errorf("%s", errorutil.FormattedError(fmt.Errorf("failed to process Step inputs: %w", err)))
+		logger.Errorf("%s", errorutil.FormattedError(fmt.Errorf("Failed to process Step inputs: %w", err))) //nolint:staticcheck
 		return exitcode.Failure
 	}
 
 	result, err := gitCloneStep.Run(cfg)
 	if err != nil {
 		logger.Println()
-		logger.Errorf("%s", errorutil.FormattedError(fmt.Errorf("failed to execute Step: %w", err)))
+		logger.Errorf("%s", errorutil.FormattedError(fmt.Errorf("Failed to execute Step: %w", err))) //nolint:staticcheck
 		return exitcode.Failure
 	}
 
 	err = gitCloneStep.ExportOutputs(result)
 	if err != nil {
 		logger.Println()
-		logger.Errorf("%s", errorutil.FormattedError(fmt.Errorf("failed to export Step outputs: %w", err)))
+		logger.Errorf("%s", errorutil.FormattedError(fmt.Errorf("Failed to export Step outputs: %w", err))) //nolint:staticcheck
 	}
 
 	fmt.Println()

--- a/step/step.go
+++ b/step/step.go
@@ -74,7 +74,7 @@ func NewGitCloneStep(logger log.Logger, tracker tracker.StepTracker, inputParser
 func (g GitCloneStep) ProcessConfig() (Config, error) {
 	var input Input
 	if err := g.inputParser.Parse(&input); err != nil {
-		return Config{}, fmt.Errorf("Error: %s\n", err)
+		return Config{}, fmt.Errorf("error: %s", err)
 	}
 	stepconf.Print(input)
 

--- a/step/step.go
+++ b/step/step.go
@@ -74,7 +74,7 @@ func NewGitCloneStep(logger log.Logger, tracker tracker.StepTracker, inputParser
 func (g GitCloneStep) ProcessConfig() (Config, error) {
 	var input Input
 	if err := g.inputParser.Parse(&input); err != nil {
-		return Config{}, fmt.Errorf("error: %s", err)
+		return Config{}, err
 	}
 	stepconf.Print(input)
 


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *NO* [version update](https://semver.org/)

### Context

Migrate the `check` workflow to use the shared `steps-check` repository via the `include:` directive, so the step benefits from centralized check workflow maintenance.

### Changes

- Replace the inline `check` workflow with an `include:` block pointing to `steps-check/steps.bitrise.yml`
- Fix `staticcheck` ST1005: lowercase error strings in `main.go` and `step/step.go`
- Fix `unparam`: mark intentionally unused parameters with `_` in `steperror.go` and `checkout_method_pr_auto_merge_branch.go`
- Add `//nolint:staticcheck` for intentionally capitalized "Bitrise" product name in error strings in `bitriseapi/`